### PR TITLE
Add vi-tality discord server

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,12 @@ https://discord.gg/uuwK9EV
 ### Doom Emacs
 https://discord.gg/qvGgnVx
 
+### VI-tality (Vim)
+https://discord.gg/yFEUve3
+
 ### Vim
 https://discord.gg/qvh2RrV
+
 
 ## Window managers
 ### Awesome

--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ https://discord.gg/uuwK9EV
 https://discord.gg/qvGgnVx
 
 ### VI-tality (Vim)
+#### Unofficial
 https://discord.gg/yFEUve3
 
 ### Vim
+#### Unofficial
 https://discord.gg/qvh2RrV
 
 


### PR DESCRIPTION
Vi-tality is a fork of the other vim server (https://discord.gg/qvh2RrV) which is currently dead. We got a nice active community with a whole bunch of vim/Linux users, EVEN dedicated NixOS cult!